### PR TITLE
Fix js typo (closing square brackets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const posts = [
       email: 'john@example.com'
     }
   }
-}
+]
 
 store.commit('entities/create', { entity: 'posts', data: posts })
 ```


### PR DESCRIPTION
Simple typo fix in documentation. Close square brackets.