### PR TITLE
Add empty data case of Repo.create

### DIFF
--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -168,6 +168,12 @@ export default class Repo {
   save (method: string, data: any): void {
     const normalizedData: NormalizedData = this.normalize(data)
 
+    // update with empty data
+    if (method === 'create' && _.isEmpty(normalizedData)) {
+      (this.query as any)[method](normalizedData)
+      return
+    }
+
     _.forEach(normalizedData, (data, entity) => {
       entity === this.name ? (this.query as any)[method](data) : (new Query(this.state, entity) as any)[method](data)
     })

--- a/src/__test__/Repo.spec.ts
+++ b/src/__test__/Repo.spec.ts
@@ -245,6 +245,26 @@ test('Repo can create a list of data in Vuex Store', (t) => {
   t.deepEqual<any>(state, expected)
 })
 
+test('Repo can create with empty data', (t) => {
+  const state = {
+    name: 'entities',
+    users: { data: {
+      '10': { id: 10 },
+      '11': { id: 11 }
+    }}
+  }
+
+  const expected = {
+    name: 'entities',
+    users: { data: {
+    }}
+  }
+
+  Repo.create(state, 'users', [])
+
+  t.deepEqual<any>(state, expected)
+})
+
 test('Repo can insert single data to Vuex Store', (t) => {
   const state = {
     name: 'entities',
@@ -294,6 +314,28 @@ test('Repo can insert a list of data to Vuex Store', (t) => {
   }
 
   Repo.insert(state, 'users', data)
+
+  t.deepEqual<any>(state, expected)
+})
+
+test('Repo can insert with empty data', (t) => {
+  const state = {
+    name: 'entities',
+    users: { data: {
+      '10': { id: 10 },
+      '11': { id: 11 }
+    }}
+  }
+
+  const expected = {
+    name: 'entities',
+    users: { data: {
+      '10': { id: 10 },
+      '11': { id: 11 }
+    }}
+  }
+
+  Repo.insert(state, 'users', [])
 
   t.deepEqual<any>(state, expected)
 })


### PR DESCRIPTION
When server API returns empty records (data: []), Repo.create couldn't update correctly.
After applying this PR, Repo.create updates empty data.

I also added tests and checked all tests passed.