### PR TITLE
Fix where clause to handle non string value

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -231,8 +231,8 @@ export default class Query {
 
         return
       }
-
-      condition = `${condition}record['${cond.field}'] == '${cond.value}'`
+      const valueText = typeof (cond.value) === 'string' ? `'${cond.value}'` : cond.value
+      condition = `${condition}record['${cond.field}'] == ${valueText}`
     })
 
     return condition

--- a/test/unit/Repo.spec.js
+++ b/test/unit/Repo.spec.js
@@ -61,20 +61,22 @@ describe('Repo', () => {
     const state = {
       name: 'entities',
       users: { data: {
-        '1': { id: 1, role: 'admin', sex: 'male' },
-        '2': { id: 2, role: 'user', sex: 'female' },
-        '3': { id: 3, role: 'admin', sex: 'male' }
+        '1': { id: 1, role: 'admin', sex: 'male', enabled: true },
+        '2': { id: 2, role: 'user', sex: 'female', enabled: true },
+        '3': { id: 3, role: 'admin', sex: 'male', enabled: true },
+        '4': { id: 4, role: 'admin', sex: 'male', enabled: false }
       }}
     }
 
     const expected = [
-      { id: 1, role: 'admin', sex: 'male' },
-      { id: 3, role: 'admin', sex: 'male' }
+      { id: 1, role: 'admin', sex: 'male', enabled: true },
+      { id: 3, role: 'admin', sex: 'male', enabled: true }
     ]
 
     const result = Repo.query(state, 'users', false)
       .where('role', 'admin')
       .where('sex', 'male')
+      .where('enabled', true)
       .get()
 
     expect(result).toEqual(expected)


### PR DESCRIPTION
I found a degration from version 0.3.
Please take a look if my fix is correct.