### PR TITLE
Fix where closure scopes in global scope

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -231,10 +231,16 @@ export default class Query {
   whereOnRecord (record: Record): boolean {
     let comparator: Function = (where: any) => {
       if (_.isFunction(where.field)) {
+        // Function with Record as argument
         return where.field(record)
       } else if (_.isFunction(where.value)) {
+        // Function with Record value as argument
         return where.value(record[where.field])
+      } else if (_.isArray(where.value)) {
+        // Check if field value is in given where Array
+        return where.value.indexOf(record[where.field]) != -1
       } else {
+        // Simple equal check
         return record[where.field] === where.value
       }
     }

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -238,7 +238,7 @@ export default class Query {
         return where.value(record[where.field])
       } else if (_.isArray(where.value)) {
         // Check if field value is in given where Array
-        return where.value.indexOf(record[where.field]) != -1
+        return where.value.indexOf(record[where.field]) !== -1
       } else {
         // Simple equal check
         return record[where.field] === where.value
@@ -256,6 +256,6 @@ export default class Query {
       whereResults.push(_.some(whereTypes.or, comparator))
     }
 
-    return whereResults.indexOf(true) != -1
+    return whereResults.indexOf(true) !== -1
   }
 }

--- a/src/support/lodash.ts
+++ b/src/support/lodash.ts
@@ -11,6 +11,9 @@ import mapValues from 'lodash-es/mapValues'
 import orderBy from 'lodash-es/orderBy'
 import pickBy from 'lodash-es/pickBy'
 import reduce from 'lodash-es/reduce'
+import every from 'lodash-es/every'
+import some from 'lodash-es/every'
+import groupBy from 'lodash-es/groupBy'
 
 export {
   forEach,
@@ -25,5 +28,8 @@ export {
   mapValues,
   orderBy,
   pickBy,
-  reduce
+  reduce,
+  every,
+  some,
+  groupBy
 }

--- a/src/support/lodash.ts
+++ b/src/support/lodash.ts
@@ -12,7 +12,7 @@ import orderBy from 'lodash-es/orderBy'
 import pickBy from 'lodash-es/pickBy'
 import reduce from 'lodash-es/reduce'
 import every from 'lodash-es/every'
-import some from 'lodash-es/every'
+import some from 'lodash-es/some'
 import groupBy from 'lodash-es/groupBy'
 
 export {

--- a/test/unit/Repo_Retrieve.spec.js
+++ b/test/unit/Repo_Retrieve.spec.js
@@ -149,6 +149,30 @@ describe('Repo: Retrieve', () => {
     expect(result).toEqual(expected)
   })
 
+  it('can get data of the entity that matches the where query with a function that accesses variables from outside the scope', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1, role: 'admin', age: 20 },
+        '2': { id: 2, role: 'user', age: 30 },
+        '3': { id: 3, role: 'admin', age: 40 }
+      }}
+    }
+
+    const expected = [
+      { id: 1, role: 'admin', age: 20 },
+      { id: 2, role: 'user', age: 30 }
+    ]
+
+    const ageAsVariable = 40
+
+    const result = Repo.query(state, 'users', false)
+      .where(r => r.age < ageAsVariable)
+      .get()
+
+    expect(result).toEqual(expected)
+  })
+
   it('can get data of the entity that matches the orWhere query', () => {
     const state = {
       name: 'entities',

--- a/test/unit/Repo_Retrieve.spec.js
+++ b/test/unit/Repo_Retrieve.spec.js
@@ -84,6 +84,32 @@ describe('Repo: Retrieve', () => {
     expect(result).toEqual(expected)
   })
 
+  it('can get all data of the entity that matches the where query value as array', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1, role: 'user', sex: 'male', enabled: true },
+        '2': { id: 2, role: 'user', sex: 'female', enabled: true },
+        '3': { id: 3, role: 'admin', sex: 'male', enabled: true },
+        '4': { id: 4, role: 'admin', sex: 'male', enabled: false },
+        '5': { id: 5, role: 'guest', sex: 'male', enabled: true }
+      }}
+    }
+
+    const expected = [
+      { id: 1, role: 'user', sex: 'male', enabled: true },
+      { id: 3, role: 'admin', sex: 'male', enabled: true }
+    ]
+
+    const result = Repo.query(state, 'users', false)
+      .where('role', ['admin', 'user'])
+      .where('sex', 'male')
+      .where('enabled', true)
+      .get()
+
+    expect(result).toEqual(expected)
+  })
+
   it('can get single data of the entity that matches the where query', () => {
     const state = {
       name: 'entities',


### PR DESCRIPTION
Hi guys, great project! We were trying to `where` with a closure but were unable to access local variables;

```javascript
const ageAsVariable = 40
const result = Repo.query(state, 'users', false)
  .where(r => r.age < ageAsVariable)
  .get()
```

This would throw an error because the function is executed in the global scope (window) and the variable doesn't exist there. This PR fixes this.

I'm not used to writing TypeScript, so please correct any errors :)