### PR TITLE
#30 Enable deleteAll without payload

### DIFF
--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -121,8 +121,8 @@ export default class Repo {
   /**
    * Delete all data from the state.
    */
-  static deleteAll (state: State, entity: string): void {
-    if (_.isEmpty(entity)) {
+  static deleteAll (state: State, entity?: string): void {
+    if (!entity) {
       const models = this.models(state)
 
       Object.keys(models).forEach((key) => {

--- a/src/modules/mutations.ts
+++ b/src/modules/mutations.ts
@@ -36,8 +36,16 @@ export default {
 
   /**
    * Delete all data from the store.
+   *
+   * @param {object} payload If exists, it should contain `entity`.
    */
-  deleteAll (state, { entity }) {
-    Repo.deleteAll(state, entity)
+  deleteAll (state, payload?) {
+    if (payload && payload.entity) {
+      Repo.deleteAll(state, payload.entity)
+
+      return
+    }
+
+    Repo.deleteAll(state)
   }
 } as Vuex.MutationTree<State>

--- a/src/modules/rootActions.ts
+++ b/src/modules/rootActions.ts
@@ -34,8 +34,10 @@ export default {
 
   /**
    * Delete all data from the store.
+   *
+   * @param {object} payload If exists, it should contain `entity`.
    */
-  deleteAll ({ commit }, { entity }) {
-    commit('deleteAll', { entity })
+  deleteAll ({ commit }, payload?) {
+    commit('deleteAll', payload)
   }
 } as Vuex.ActionTree<any, any>

--- a/test/feature/RootModules.spec.js
+++ b/test/feature/RootModules.spec.js
@@ -116,6 +116,26 @@ describe('Root modules', () => {
     await store.dispatch('entities/create', { entity: 'users', data: users })
     await store.dispatch('entities/create', { entity: 'posts', data: posts })
 
+    await store.dispatch('entities/deleteAll')
+
+    expect(store.getters['entities/users/all']().length).toBe(0)
+    expect(store.getters['entities/posts/all']().length).toBe(0)
+  })
+
+  it('can delete all data when passing empty object', async () => {
+    const store = createStore(entities)
+
+    const users = [
+      { id: 1 }, { id: 2 }, { id: 3 }
+    ]
+
+    const posts = [
+      { id: 1, user_id: 1 }, { id: 2, user_id: 2 }, { id: 3, user_id: 3 }
+    ]
+
+    await store.dispatch('entities/create', { entity: 'users', data: users })
+    await store.dispatch('entities/create', { entity: 'posts', data: posts })
+
     await store.dispatch('entities/deleteAll', {})
 
     expect(store.getters['entities/users/all']().length).toBe(0)


### PR DESCRIPTION
Issue: #30 

This PR makes `deleteAll` method work without payload.

@mastermunj, Sorry to bother you but I just wanted to check you in on this PR. It seems like this change makes it possible to use delete all method without an empty object.

Did you have any specific concern with implementation? The test is passing, but I wanted to make sure I'm not missing something.

May I ask you to review this code briefly 🙏 

```js
dispatch('entities/deleteAll') // Now this works.

dispatch('entities/deleteAll', {}) // This still works too.
```