### PR TITLE
#25 Fill missing fields with model's default value when creating new data

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -318,24 +318,31 @@ export default class Model {
    * Serialize field values into json.
    */
   $toJson (): any {
-    return _.mapValues(this.$self().fields(), (attr, key) => {
-      if (!this[key]) {
-        return this[key]
+    return this.$buildJson(this.$self().fields(), this)
+  }
+
+  /**
+   * Build Json data.
+   */
+  $buildJson (data: Fields, field: { [key: string]: any }): any {
+    return _.mapValues(data, (attr, key) => {
+      if (!field[key]) {
+        return field[key]
       }
 
       if (!Attributes.isRelation(attr)) {
-        return
+        return field.$buildJson(attr, field[key])
       }
 
       if (attr.type === AttrType.HasOne || attr.type === AttrType.BelongsTo) {
-        return this[key].$toJson()
+        return field[key].$toJson()
       }
 
       if (attr.type === AttrType.HasMany) {
-        return this[key].map((model: Model) => model.$toJson())
+        return field[key].map((model: Model) => model.$toJson())
       }
 
-      return this[key]
+      return field[key]
     })
   }
 }

--- a/test/fixtures/models/User.js
+++ b/test/fixtures/models/User.js
@@ -11,6 +11,7 @@ export default class User extends Model {
       id: this.attr(null),
       name: this.attr(''),
       settings: {
+        role: this.attr(''),
         accounts: this.hasMany(Account, 'user_id')
       },
       posts: this.hasMany(Post, 'user_id'),

--- a/test/unit/Repo_Create.spec.js
+++ b/test/unit/Repo_Create.spec.js
@@ -39,15 +39,55 @@ describe('Repo: Create', () => {
     const expected = {
       name: 'entities',
       posts: { data: {
-        '1': { id: 1, comments: [1, 2] }
+        '1': {
+          id: 1,
+          user_id: null,
+          author: null,
+          comments: [1, 2],
+          reviews: []
+        }
       }},
       comments: { data: {
-        '1': { id: 1, post_id: 1 },
-        '2': { id: 2, post_id: 1 }
+        '1': { id: 1, post_id: 1, body: '', post: null, likes: [] },
+        '2': { id: 2, post_id: 1, body: '', post: null, likes: [] }
       }}
     }
 
     Repo.create(state, 'posts', data)
+
+    expect(state).toEqual(expected)
+  })
+
+  it('can create a single data with nested object schema in Vuex Store', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {} }
+    }
+
+    const data = {
+      id: 1,
+      settings: {
+        role: 'admin'
+      }
+    }
+
+    const expected = {
+      name: 'entities',
+      users: { data: {
+        '1': {
+          id: 1,
+          name: '',
+          settings: {
+            role: 'admin',
+            accounts: []
+          },
+          posts: [],
+          profile: null
+        }
+      }}
+    }
+
+    Repo.create(state, 'users', data)
 
     expect(state).toEqual(expected)
   })
@@ -81,17 +121,17 @@ describe('Repo: Create', () => {
     const expected = {
       name: 'entities',
       users: { data: {
-        '10': { id: 10 },
-        '11': { id: 11 }
+        '10': { id: 10, name: '', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '11': { id: 11, name: '', settings: { accounts: [], role: '' }, posts: [], profile: null }
       }},
       posts: { data: {
         '1': { id: 1, user_id: 10, author: 10, comments: [1], reviews: [1, 2] },
         '2': { id: 2, user_id: 11, author: 11, comments: [2, 3], reviews: [3, 4] }
       }},
       comments: { data: {
-        '1': { id: 1, post_id: 1, body: 'C1' },
-        '2': { id: 2, post_id: 2, body: 'C2' },
-        '3': { id: 3, post_id: 2, body: 'C3' }
+        '1': { id: 1, post_id: 1, body: 'C1', post: null, likes: [] },
+        '2': { id: 2, post_id: 2, body: 'C2', post: null, likes: [] },
+        '3': { id: 3, post_id: 2, body: 'C3', post: null, likes: [] }
       }},
       reviews: { data: {} }
     }
@@ -148,8 +188,8 @@ describe('Repo: Create', () => {
     const state = {
       name: 'entities',
       users: { data: {
-        '1': { id: 1, name: 'John' },
-        '2': { id: 2, name: 'Jane' }
+        '1': { id: 1, name: 'John', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '2': { id: 2, name: 'Jane', settings: { accounts: [], role: '' }, posts: [], profile: null }
       }}
     }
 
@@ -158,9 +198,9 @@ describe('Repo: Create', () => {
     const expected = {
       name: 'entities',
       users: { data: {
-        '1': { id: 1, name: 'John' },
-        '2': { id: 2, name: 'Jane' },
-        '3': { id: 3, name: 'Johnny' }
+        '1': { id: 1, name: 'John', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '2': { id: 2, name: 'Jane', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '3': { id: 3, name: 'Johnny', settings: { accounts: [], role: '' }, posts: [], profile: null }
       }}
     }
 
@@ -173,8 +213,8 @@ describe('Repo: Create', () => {
     const state = {
       name: 'entities',
       users: { data: {
-        '1': { id: 1, name: 'John' },
-        '2': { id: 2, name: 'Jane' }
+        '1': { id: 1, name: 'John', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '2': { id: 2, name: 'Jane', settings: { accounts: [], role: '' }, posts: [], profile: null }
       }}
     }
 
@@ -186,9 +226,9 @@ describe('Repo: Create', () => {
     const expected = {
       name: 'entities',
       users: { data: {
-        '1': { id: 1, name: 'Janie' },
-        '2': { id: 2, name: 'Jane' },
-        '3': { id: 3, name: 'Johnny' }
+        '1': { id: 1, name: 'Janie', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '2': { id: 2, name: 'Jane', settings: { accounts: [], role: '' }, posts: [], profile: null },
+        '3': { id: 3, name: 'Johnny', settings: { accounts: [], role: '' }, posts: [], profile: null }
       }}
     }
 


### PR DESCRIPTION
Issue: #25, #29 

This PR makes `create` and `insert` action to fill missing model fields with default value when saving data to the store.

### Behavior Change

Now any field of data passed to `create` and `insert` action which doesn't exist in the Model's fields will be ignored.

```js
// When you have these fields.
class Users extends Model {
  static fields () {
    return {
      id: this.attr(null),
      name: this.attr('')
    }
  }
}

// And pass this kind of data.
store.dispatch('entities/users/create', {
  data: {
    id: 1,
    age: 24
  }
})

// This data will be saved to store. There is `name` but no `age` here.
{
  id: 1,
  name: ''
}
```

@CinKon Would you mind taking a look at the **Behavior Change**? Do you think this would be OK? or should I make non defined data (`age` in the above example) to be saved in the store?