### PR TITLE
#32 Add has and hasNot method to query depending on relationship existence and absence

### DIFF
--- a/docs/store/retrieving-data.md
+++ b/docs/store/retrieving-data.md
@@ -290,3 +290,57 @@ const user = store.getters['entities/users/query']().with('posts', (query) => {
   }
 */
 ```
+
+#### Querying Relationship Existence
+
+When querying the record, you may wish to limit your results based on the existence of a relationship. For example, imagine you want to retrieve all blog posts that have at least one comment. To do so, you may pass the name of the relationship to the has methods.
+
+```js
+// Retrieve all posts that have at least one comment.
+store.getters['entities/posts/query']().has('comments').get()
+```
+
+You may also specify count as well.
+
+```js
+// Retrieve all posts that have at least 2 comments.
+store.getters['entities/posts/query']().has('comments', 2).get()
+```
+
+Also you may add operator to customize your query even more. The supported operators are `>`, `>=`, `<` and `<=`.
+
+```js
+// Retrieve all posts that have more than 2 comments.
+store.getters['entities/posts/query']().has('comments', '>' 2).get()
+
+// Retrieve all posts that have less than or exactly 3 comments.
+store.getters['entities/posts/query']().has('comments', '<=' 2).get()
+```
+
+And even more, you can pass closure for complex query. If closure may return boolean, or it can just add constraints to the query.
+
+```js
+// Retrieve all posts that have user_id of 1.
+store.getters['entities/posts/query']().has('comments', (query) => {
+  query.where('user_id', 1)
+}).get()
+
+// Retrieve all posts that have more than 2 comments with user_id of 1.
+store.getters['entities/posts/query']().has('comments', (query) => {
+  return query.where('user_id', 1).count() > 2
+}).get()
+```
+
+#### Querying Relationship Absence
+
+To retrieve records depending on absence of the relationship, use `hasNot` method. `hasNot` method will work same as `has` but in opposite result.
+
+```js
+// Retrieve all posts that doesn't have comments.
+store.getters['entities/posts/query']().hasNot('comments').get()
+
+// Retrieve all posts that doesn't have comment with user_id of 1.
+store.getters['entities/posts/query']().hasNot('comments', (query) => {
+  query.where('user_id', 1)
+}).get()
+```

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -15,7 +15,7 @@ export type Predicate = (item: Record) => boolean
 export type Condition = number | string | Predicate
 
 export interface Wheres {
-  field: string
+  field: any
   value: any
   boolean: WhereBoolean
 }
@@ -162,7 +162,7 @@ export default class Query {
   /**
    * Add a and where clause to the query.
    */
-  where (field: string, value: any): this {
+  where (field: any, value?: any): this {
     this.wheres.push({ field, value, boolean: 'and' })
 
     return this
@@ -171,7 +171,7 @@ export default class Query {
   /**
    * Add a or where clause to the query.
    */
-  orWhere (field: string, value: any): this {
+  orWhere (field: any, value?: any): this {
     this.wheres.push({ field, value, boolean: 'or' })
 
     return this

--- a/src/Repo.ts
+++ b/src/Repo.ts
@@ -17,7 +17,7 @@ export type Collection = Model[] | Record[]
 
 export type Buildable = QueryItem | QueryCollection | null
 
-export type Constraint = (query: Repo) => void
+export type Constraint = (query: Repo) => void | boolean
 
 export interface Relation {
   name: string
@@ -198,7 +198,7 @@ export default class Repo {
   /**
    * Add a and where clause to the query.
    */
-  where (field: string, value: any): this {
+  where (field: any, value?: any): this {
     this.query.where(field, value)
 
     return this
@@ -207,7 +207,7 @@ export default class Repo {
   /**
    * Add a or where clause to the query.
    */
-  orWhere (field: string, value: any): this {
+  orWhere (field: any, value?: any): this {
     this.query.orWhere(field, value)
 
     return this
@@ -245,6 +245,37 @@ export default class Repo {
    */
   with (name: string, constraint: Constraint | null = null): this {
     this.load.push({ name, constraint })
+
+    return this
+  }
+
+  /**
+   * Set where constraint based on relationship existence.
+   */
+  has (name: string, constraint: null | Constraint = null): this {
+    return this.addHasConstraint(name, constraint, true)
+  }
+
+  /**
+   * Set where constraint based on relationship absence.
+   */
+  hasNot (name: string, constraint: null | Constraint = null): this {
+    return this.addHasConstraint(name, constraint, false)
+  }
+
+  /**
+   * Add where constraints based on has or hasNot condition.
+   */
+  addHasConstraint (name: string, constraint: null | Constraint = null, existence: boolean = true): this {
+    const items = (new Query(this.state, this.name)).get()
+    const id = this.model(this.name).primaryKey
+    const ids: any[] = []
+
+    _.forEach(items, (item) => {
+      this.hasRelation(item, name, constraint) === existence && ids.push(item[id])
+    })
+
+    this.where(id, (key: any) => _.includes(ids, key))
 
     return this
   }
@@ -421,18 +452,19 @@ export default class Repo {
   /**
    * Load the relationships for the record.
    */
-  loadRelations (base: Record, record?: Record, fields?: Fields): Record {
+  loadRelations (base: Record, load?: Relation[], record?: Record, fields?: Fields): Record {
+    const _load = load || this.load
     const _record = record || { ...base }
     const _fields = fields || this.entity.fields()
 
-    return _.reduce(this.load, (record, relation) => {
+    return _.reduce(_load, (record, relation) => {
       const name = relation.name.split('.')[0]
       const attr = _fields[name]
 
       if (!attr || !Attrs.isRelation(attr)) {
         _.forEach(_fields, (f: any, key: string) => {
           if (f[name]) {
-            record[key] = this.loadRelations(base, record[key], f)
+            record[key] = this.loadRelations(base, _load, record[key], f)
 
             return
           }
@@ -543,20 +575,33 @@ export default class Repo {
   }
 
   /**
+   * Check if the given record has given relationship.
+   */
+  hasRelation (record: Record, name: string, constraint: null | Constraint = null): boolean {
+    const data = this.loadRelations(record, [{ name, constraint }])
+
+    return !_.isEmpty(data[name])
+  }
+
+  /**
    * Add constraint to the query.
    */
   addConstraint (query: Repo, relation: Relation): void {
     const relations = relation.name.split('.')
 
-    if (relations.length === 1) {
-      relation.constraint && relation.constraint(query)
+    if (relations.length !== 1) {
+      relations.shift()
+
+      query.with(relations.join('.'))
 
       return
     }
 
-    relations.shift()
+    const result = relation.constraint && relation.constraint(query)
 
-    query.with(relations.join('.'))
+    if (typeof result === 'boolean') {
+      query.where(() => result)
+    }
   }
 
   /**

--- a/test/unit/Repo_Retrieve.spec.js
+++ b/test/unit/Repo_Retrieve.spec.js
@@ -622,4 +622,144 @@ describe('Repo: Retrieve', () => {
 
     expect(post).toEqual(expected)
   })
+
+  it('can query data depending on relationship existence', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1 },
+        '2': { id: 2, user_id: 2 },
+        '3': { id: 3, user_id: 2 }
+      }}
+    }
+
+    const expected = [{ id: 1 }, { id: 2 }]
+
+    const users = Repo.query(state, 'users', false).has('posts').get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship absence', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1 },
+        '2': { id: 2, user_id: 2 },
+        '3': { id: 3, user_id: 2 }
+      }}
+    }
+
+    const expected = [{ id: 3 }]
+
+    const users = Repo.query(state, 'users', false).hasNot('posts').get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship existence with constraint', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 2 }]
+
+    const users = Repo.query(state, 'users', false)
+      .has('posts', query => query.where('type', 'event'))
+      .get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship absence with constraint', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 1 }, { id: 3 }]
+
+    const users = Repo.query(state, 'users', false)
+      .hasNot('posts', query => query.where('type', 'event'))
+      .get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship existence with count', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 2 }]
+
+    const users = Repo.query(state, 'users', false)
+      .has('posts', query => query.count() > 1)
+      .get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it.only('can query data depending on relationship absence with count', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 1 }, { id: 3 }]
+
+    const users = Repo.query(state, 'users', false)
+      .hasNot('posts', query => query.count() > 1)
+      .get()
+
+    expect(users).toEqual(expected)
+  })
 })

--- a/test/unit/Repo_Retrieve.spec.js
+++ b/test/unit/Repo_Retrieve.spec.js
@@ -739,7 +739,7 @@ describe('Repo: Retrieve', () => {
     expect(users).toEqual(expected)
   })
 
-  it.only('can query data depending on relationship absence with count', () => {
+  it('can query data depending on relationship absence with count', () => {
     const state = {
       name: 'entities',
       users: { data: {
@@ -761,5 +761,91 @@ describe('Repo: Retrieve', () => {
       .get()
 
     expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship existence with number', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 2 }]
+
+    const users = Repo.query(state, 'users', false).has('posts', 2).get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship absence with number', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    const expected = [{ id: 1 }, { id: 3 }]
+
+    const users = Repo.query(state, 'users', false).hasNot('posts', 2).get()
+
+    expect(users).toEqual(expected)
+  })
+
+  it('can query data depending on relationship existence with string conditions', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    expect(Repo.query(state, 'users', false).has('posts', '>', 1).get()).toEqual([{ id: 2 }])
+    expect(Repo.query(state, 'users', false).has('posts', '>=', 1).get()).toEqual([{ id: 1 }, { id: 2 }])
+    expect(Repo.query(state, 'users', false).has('posts', '<', 2).get()).toEqual([{ id: 1 }])
+    expect(Repo.query(state, 'users', false).has('posts', '<=', 2).get()).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('can query data depending on relationship absence with string conditions', () => {
+    const state = {
+      name: 'entities',
+      users: { data: {
+        '1': { id: 1 },
+        '2': { id: 2 },
+        '3': { id: 3 }
+      }},
+      posts: { data: {
+        '1': { id: 1, user_id: 1, type: 'news' },
+        '2': { id: 2, user_id: 2, type: 'event' },
+        '3': { id: 3, user_id: 2, type: 'news' }
+      }}
+    }
+
+    expect(Repo.query(state, 'users', false).hasNot('posts', '>', 1).get()).toEqual([{ id: 1 }, { id: 3 }])
+    expect(Repo.query(state, 'users', false).hasNot('posts', '>=', 1).get()).toEqual([{ id: 3 }])
+    expect(Repo.query(state, 'users', false).hasNot('posts', '<', 2).get()).toEqual([{ id: 2 }, { id: 3 }])
+    expect(Repo.query(state, 'users', false).hasNot('posts', '<=', 2).get()).toEqual([{ id: 3 }])
   })
 })


### PR DESCRIPTION
Issue: #32 

This PR adds `has` and `hasNot` method as explained in issue #32.