### PR TITLE
#37 Add the plugin feature

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Vuex ORM lets you create "normalized" data schema within Vuex Store with relatio
     - [Creating And Updating Data](store/creating-and-updating-data.md)
     - [Retrieving Data](store/retrieving-data.md)
     - [Deleting Data](store/deleting-data.md)
+- [Plugins](plugins.md)
 - [API Reference](api-reference.md)
     - [Model](api/model.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,5 +13,6 @@
     - [Creating And Updating Data](store/creating-and-updating-data.md)
     - [Retrieving Data](store/retrieving-data.md)
     - [Deleting Data](store/deleting-data.md)
+- [Plugins](plugins.md)
 - [API Reference](api-reference.md)
     - [Model](api/model.md)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,51 @@
+# Plugins
+
+You may add additional feature to the Vuex ORM through plugins. Plugins usually add global-level functionality to Vuex ORM. Vuex ORM plugin workd very similer to [Vue Plugin](https://vuex.vuejs.org/en/plugins.html).
+
+## Writing a Plugin
+
+A Vuex ORM plugin should be an object that exposes an install method. The method will be called with the Vuex ORM components such as Model, Repo, Query and such as the first argument, along with possible options.
+
+```js
+const plugin = {
+  // `components` contains Vuex ORM objects such as Model, Repo, or Query.
+  // The plugin author can then extend those objects to add whatever
+  // features it needs.
+  install (components, options) {
+    // Add global (static) method or property.
+    components.Model.globalMethod = function () {
+      // Logic...
+    }
+
+    // Add an instance method or property.
+    components.Repo.prototype.instanceMethod = function () {
+      // Logic...
+    }
+  }
+}
+```
+
+### Components
+
+Following components are included within `components` argument.
+
+- Model
+- Repo
+- Query
+
+## Using a Plugin
+
+Use plugins by calling the VuexORM.use() method.
+
+```js
+import VuexORM from 'vuex-orm'
+import plugin from 'vuex-orm-plugin'
+
+VuexORM.use(plugin)
+```
+
+You can optionally pass in some options too.
+
+```js
+VuexORM.use(plugin, { someOption: true })
+```

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -27,11 +27,6 @@ export interface Orders {
 
 export default class Query {
   /**
-   * @protected records store query instance records for accessing and manipulation during query chain
-   */
-  protected records: Records
-
-  /**
    * The Vuex Store State. This is the target where query will perform
    * CRUD actions.
    */
@@ -51,6 +46,11 @@ export default class Query {
    * The data of the entity.
    */
   protected entity: EntityState
+
+  /**
+   * The records that have been processed.
+   */
+  protected records: Records
 
   /**
    * The where constraints for the query.
@@ -90,9 +90,8 @@ export default class Query {
    */
   get (): Collection {
     this.process()
-    const records: Records = this.records
 
-    return this.collect(records)
+    return this.collect(this.records)
   }
 
   /**
@@ -100,17 +99,16 @@ export default class Query {
    */
   first (id?: number | string): Item {
     this.process()
-    let records: Records = this.records
 
     if (_.isEmpty(this.records)) {
       return null
     }
 
     if (id !== undefined) {
-      return records[id] ? this.item(records[id]) : null
+      return this.records[id] ? this.item(this.records[id]) : null
     }
 
-    const sortedRecord = this.sortByOrders(records)
+    const sortedRecord = this.sortByOrders(this.records)
 
     return this.item(sortedRecord[0])
   }
@@ -153,18 +151,14 @@ export default class Query {
    * Process the query and filter data.
    */
   process (): void {
-    // First, fetch all records of the entity.
-    let records: Records = this.records
-
-    // If the entity is empty, there's nothing we can do so lets return
-    // data as is and exit immediately.
-    if (_.isEmpty(records)) {
+    // If the records is empty, there's nothing we can do so lets
+    // return immediately.
+    if (_.isEmpty(this.records)) {
       return
     }
 
     // Now since we have the records, lets check if the where clause is
-    // registered. If not, there is nothing we need to do so just
-    // return all data.
+    // registered. If not, there is nothing we need to do so just exit.
     if (_.isEmpty(this.wheres)) {
       return
     }

--- a/src/index.cjs.ts
+++ b/src/index.cjs.ts
@@ -1,15 +1,24 @@
 import install, { Install } from './store/install'
+import use, { Use } from './plugins/use'
 import Database from './Database'
 import Model from './Model'
+import Repo from './Repo'
+import Query from './Query'
 
 export interface VuexORM {
   install: Install
+  use: Use
   Database: typeof Database
   Model: typeof Model
+  Repo: typeof Repo
+  Query: typeof Query
 }
 
 export default {
   install,
+  use,
   Database,
-  Model
+  Model,
+  Repo,
+  Query
 } as VuexORM

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,25 @@
 import install, { Install } from './store/install'
+import use, { Use } from './plugins/use'
 import Database from './Database'
 import Model from './Model'
 
 export interface VuexORM {
   install: Install
+  use: Use
   Database: typeof Database
   Model: typeof Model
 }
 
 export default {
   install,
+  use,
   Database,
   Model
 } as VuexORM
 
 export {
   install,
+  use,
   Database,
   Model
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,24 +2,32 @@ import install, { Install } from './store/install'
 import use, { Use } from './plugins/use'
 import Database from './Database'
 import Model from './Model'
+import Repo from './Repo'
+import Query from './Query'
 
 export interface VuexORM {
   install: Install
   use: Use
   Database: typeof Database
   Model: typeof Model
+  Repo: typeof Repo
+  Query: typeof Query
 }
 
 export default {
   install,
   use,
   Database,
-  Model
+  Model,
+  Repo,
+  Query
 } as VuexORM
 
 export {
   install,
   use,
   Database,
-  Model
+  Model,
+  Repo,
+  Query
 }

--- a/src/plugins/use.ts
+++ b/src/plugins/use.ts
@@ -1,0 +1,18 @@
+import Model from '../Model'
+import Repo from '../Repo'
+
+export interface Components {
+  Model: typeof Model
+  Repo: typeof Repo
+}
+
+export interface Plugin {
+  install: (components: Components, options: { [key: string]: any }) => void
+  [key: string]: any
+}
+
+export type Use = (plugin: Plugin) => void
+
+export default function (plugin: Plugin, options: { [key: string]: any } = {}): void {
+  plugin.install({ Model, Repo }, options)
+}

--- a/src/plugins/use.ts
+++ b/src/plugins/use.ts
@@ -1,9 +1,11 @@
 import Model from '../Model'
 import Repo from '../Repo'
+import Query from '../Query'
 
 export interface Components {
   Model: typeof Model
   Repo: typeof Repo
+  Query: typeof Query
 }
 
 export interface Plugin {
@@ -14,5 +16,5 @@ export interface Plugin {
 export type Use = (plugin: Plugin) => void
 
 export default function (plugin: Plugin, options: { [key: string]: any } = {}): void {
-  plugin.install({ Model, Repo }, options)
+  plugin.install({ Model, Repo, Query }, options)
 }

--- a/test/feature/Plugin.spec.js
+++ b/test/feature/Plugin.spec.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import VuexORM from 'app'
 import Model from 'app/Model'
+import Query from 'app/Query'
 
 class User extends Model {
   static entity = 'users'
@@ -74,5 +75,31 @@ describe('Plugin', () => {
     const repo = store.getters['entities/users/query']()
 
     expect(repo.instanceMethod()).toBe('Hello, world!')
+  })
+
+  it('add additional feature to the Query', async () => {
+    const plugin = {
+      install (components) {
+        components.Repo.prototype.newQuery = function () {
+          return new Query(this.state, this.name, this.primaryKey)
+        }
+
+        components.Query.prototype.instanceMethod = function () {
+          return 'Hello, world!'
+        }
+      }
+    }
+
+    VuexORM.use(plugin)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)]
+    })
+
+    await store.dispatch('entities/users/create', { data: { id: 1, name: 'John' } })
+
+    const repo = store.getters['entities/users/query']()
+
+    expect(repo.newQuery().instanceMethod()).toBe('Hello, world!')
   })
 })

--- a/test/feature/Plugin.spec.js
+++ b/test/feature/Plugin.spec.js
@@ -1,0 +1,78 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import VuexORM from 'app'
+import Model from 'app/Model'
+
+class User extends Model {
+  static entity = 'users'
+
+  static fields () {
+    return {
+      id: this.attr(null),
+      name: this.attr('')
+    }
+  }
+}
+
+const database = new VuexORM.Database()
+
+database.register(User, {})
+
+Vue.use(Vuex)
+
+describe('Plugin', () => {
+  it('add additional feature to the Model', async () => {
+    const plugin = {
+      install (components) {
+        components.Model.staticMethod = function () {
+          return 'Hello'
+        }
+
+        components.Model.prototype.instanceProperty = ', world!'
+
+        components.Model.prototype.instanceMethod = function () {
+          return `${this.$self().staticMethod()}${this.instanceProperty}`
+        }
+      }
+    }
+
+    VuexORM.use(plugin)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)]
+    })
+
+    await store.dispatch('entities/users/create', { data: { id: 1, name: 'John' } })
+
+    const user = store.getters['entities/users/find'](1)
+
+    expect(user.id).toBe(1)
+    expect(user.instanceMethod()).toBe('Hello, world!')
+  })
+
+  it('add additional feature to the Repo', async () => {
+    const plugin = {
+      install (components) {
+        components.Repo.staticMethod = function () {
+          return 'Hello'
+        }
+
+        components.Repo.prototype.instanceMethod = function () {
+          return `${this.self().staticMethod()}, world!`
+        }
+      }
+    }
+
+    VuexORM.use(plugin)
+
+    const store = new Vuex.Store({
+      plugins: [VuexORM.install(database)]
+    })
+
+    await store.dispatch('entities/users/create', { data: { id: 1, name: 'John' } })
+
+    const repo = store.getters['entities/users/query']()
+
+    expect(repo.instanceMethod()).toBe('Hello, world!')
+  })
+})


### PR DESCRIPTION
Issue: #37 

This PR adds "plugin" feature to the Vuex ORM. It will enable 3rd party library to add new functionality to Vuex ORM.

### Plugin Structure

A Vuex ORM plugin should be an object that exposes an `install` method. The method will be called with the Vuex ORM components such as Model, Repo, Query and such as the first argument, along with possible options.

```js
const plugin = {
  // `components` contains Vuex ORM objects such as Model, Repo, or Query.
  // The plugin author can then extend those objects to add whatever
  // features it needs.
  install (components, options) {
    // Add global (static) method or property.
    components.Model.globalMethod = function () {
      // Logic...
    }

    // Add an instance method or property.
    components.Repo.prototype.instanceMethod = function () {
      // Logic...
    }
  }
}
```

### Using Plugin

Install the plugin to Vuex ORM through `use` method.

```js
import VuexORM from 'vuex-orm'
import plugin from 'vuex-orm-plugin'

VuexORM.use(plugin)
```

You can optionally pass in some options too.


```js
VuexORM.use(plugin, { someOption: true })
```