### PR TITLE
Replace database handle to store with Container.store

### DIFF
--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -190,8 +190,8 @@ export default class Database {
     const database = this
 
     const c = class extends model {
-      static store (): Store<any> {
-        return database.store
+      static database (): Database {
+        return database
       }
     }
 

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -29,11 +29,6 @@ export type Modules = Record<string, Module<State, any>>
 
 export default class Database {
   /**
-   * The Vuex Store instance.
-   */
-  store!: Store<any>
-
-  /**
    * The namespace for the Vuex Module. Vuex ORM will create Vuex Modules from the
    * registered models and modules and define them under this namespace.
    */
@@ -60,12 +55,11 @@ export default class Database {
    * Initialize the database before a user can start using it.
    */
   start (store: Store<any>, namespace: string): void {
-    this.store = store
     this.namespace = namespace
 
-    this.connect()
+    this.connect(store)
 
-    this.registerModules()
+    this.registerModules(store)
     this.createSchema()
 
     this.isStarted = true
@@ -87,7 +81,7 @@ export default class Database {
     this.entities.push(entity)
 
     if (this.isStarted) {
-      this.registerModule(entity)
+      this.registerModule(entity, model.store())
       this.registerSchema(entity)
     }
   }
@@ -179,8 +173,8 @@ export default class Database {
   /**
    * Get the root state from the store.
    */
-  getState (): RootState {
-    return this.store.state[this.namespace]
+  getState (store: Store<any>): RootState {
+    return store.state[this.namespace]
   }
 
   /**
@@ -204,22 +198,22 @@ export default class Database {
    * Create Vuex Module from the registered entities, and register to
    * the store.
    */
-  private registerModules (): void {
-    this.store.registerModule(this.namespace, this.createModule())
+  private registerModules (store: Store<any>): void {
+    store.registerModule(this.namespace, this.createModule(store))
   }
 
   /**
    * Generate module from the given entity, and register to the store.
    */
-  private registerModule (entity: Entity): void {
-    this.store.registerModule([this.namespace, entity.name], this.createSubModule(entity))
+  private registerModule (entity: Entity, store: Store<any>): void {
+    store.registerModule([this.namespace, entity.name], this.createSubModule(entity))
   }
 
   /**
    * Create Vuex Module from the registered entities.
    */
-  private createModule (): Module<any, any> {
-    const module = this.createRootModule()
+  private createModule (store: Store<any>): Module<any, any> {
+    const module = this.createRootModule(store)
 
     this.entities.forEach((entity) => {
       module.modules[entity.name] = this.createSubModule(entity)
@@ -231,11 +225,11 @@ export default class Database {
   /**
    * Create root module.
    */
-  private createRootModule (): ModuleContract {
+  private createRootModule (store: Store<any>): ModuleContract {
     return {
       namespaced: true,
       state: this.createRootState(),
-      getters: this.createRootGetters(),
+      getters: this.createRootGetters(store),
       actions: this.createRootActions(),
       mutations: this.createRootMutations(),
       modules: {}
@@ -254,9 +248,9 @@ export default class Database {
    * function to retrieve database instances within getters. We only need this
    * for the getter since actions and mutations are already bound to store.
    */
-  private createRootGetters (): RootGettersContract {
+  private createRootGetters (store: Store<any>): RootGettersContract {
     return mapValues(RootGetters, (_getter, name) => {
-      return RootGetters[name].bind(this.store)
+      return RootGetters[name].bind(store)
     })
   }
 
@@ -347,8 +341,8 @@ export default class Database {
   /**
    * Inject database to the store instance.
    */
-  private connect (): void {
-    this.store.$db = () => this
+  private connect (store: Store<any>): void {
+    store.$db = () => this
   }
 
   /**

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -147,7 +147,7 @@ export default class Query<T extends Model = Model> {
     this.entity = entity
     this.baseEntity = this.baseModel.entity
 
-    this.rootState = this.database.getState()
+    this.rootState = this.database.getState(store)
     this.state = this.rootState[this.baseEntity]
 
     this.appliedOnBase = this.baseEntity === this.entity
@@ -161,7 +161,7 @@ export default class Query<T extends Model = Model> {
     const models = database.models()
 
     for (const entity in models) {
-      const state = database.getState()[entity]
+      const state = database.getState(store)[entity]
       state && (new this(store, entity)).deleteAll()
     }
   }

--- a/src/store/install.ts
+++ b/src/store/install.ts
@@ -12,8 +12,7 @@ export default (database: Database, options: Options = {}): Vuex.Plugin<any> => 
   const namespace = options.namespace || 'entities'
 
   return (store: Vuex.Store<any>): void => {
-    database.start(store, namespace)
-
     Container.register(store)
+    database.start(store, namespace)
   }
 }


### PR DESCRIPTION
With only one global handle to the Vuex store, it allows me to hot swap the store.

```js
const database = new VuexORM.Database();
const mainStore = new Vuex.Store();
const alternateStore = new Vuex.Store();
VuexORM.install(database)(mainStore);
alternateStore.registerModule('entities', database.createModule());

// Do various model operations

VuexORM.Container.register(alternateStore); // Swap entire state

// Do other operations

VuexORM.Container.register(mainStore); // Swap entire state back
```

This can be further extended by having Model instances store the `store` instance, change Model.$store() to return it, and all Model.$___() methods to call this.$store() instead of this.$self(), then the model instance can operate on itself while its store is not registered in Container.

The only remaining catch that I need to work out is to swap the observers between the stores to allow existing queries (and Vues) to be updated with the swapped state.