### PR TITLE
feat: add when query helper

### DIFF
--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -329,6 +329,25 @@ export default class Query<T extends Model = Model> {
   }
 
   /**
+   * Runs a query conditionally.
+   */
+  when(
+    conditional: any,
+    callback: (query: this, conditional: any) => void | this,
+    defaultCallback?: (query: this, conditional: any) => void | this
+  ): this {
+    if (conditional) {
+      return callback(this, conditional) || this
+    }
+
+    if (defaultCallback) {
+      return defaultCallback(this, conditional) || this
+    }
+
+    return this
+  }
+
+  /**
    * Add a and where clause to the query.
    */
   where(field: any, value?: any): this {

--- a/test/feature/basics/Retrieve.spec.ts
+++ b/test/feature/basics/Retrieve.spec.ts
@@ -134,6 +134,77 @@ describe('Feature – Retrieve', () => {
     expect(user).toEqual(expected)
   })
 
+  it('can query when a conditional is truthy', async () => {
+    createStore([{ model: User }])
+
+    await User.insert({
+      data: [{ id: 1 }, { id: 2 }]
+    })
+
+    const expected = [{ $id: '2', id: 2 }]
+
+    const user = User.query()
+      .when(true, (query, conditional) => {
+        query.where('id', 2)
+
+        expect(conditional).toBe(true)
+      })
+      .all()
+
+    expect(user).toEqual(expected)
+  })
+
+  it('will not query when a conditional is falsy', async () => {
+    createStore([{ model: User }])
+
+    await User.insert({
+      data: [{ id: 1 }, { id: 2 }]
+    })
+
+    const expected = [
+      { $id: '1', id: 1 },
+      { $id: '2', id: 2 }
+    ]
+
+    const user = User.query()
+      .when(false, (query, conditional) => {
+        query.where('id', 2)
+
+        expect(conditional).toBe(false)
+      })
+      .all()
+
+    expect(user).toEqual(expected)
+  })
+
+  it('uses a fallback query when the conditional is falsy', async () => {
+    createStore([{ model: User }])
+
+    await User.insert({
+      data: [{ id: 1 }, { id: 2 }]
+    })
+
+    const expected = [{ $id: '1', id: 1 }]
+
+    const user = User.query()
+      .when(
+        false,
+        (query, conditional) => {
+          query.where('id', 2)
+
+          expect(conditional).toBe(false)
+        },
+        (query, conditional) => {
+          query.where('id', 1)
+
+          expect(conditional).toBe(false)
+        }
+      )
+      .all()
+
+    expect(user).toEqual(expected)
+  })
+
   describe('#first', () => {
     it('can retrieve the first item from the store', async () => {
       createStore([{ model: User }])


### PR DESCRIPTION
First of all, I want to thank y'all for this amazing package. It solved a lot of problems with the project I'm currently working on.

However, I felt that one helper function was missing; `when`. This PR will add the `when` helper method, which will take a conditional and, if the conditional is true, will wrap this inside the callback.
More details below.

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

On my current project, I have to filter multiple entities and search each one of them as well. Right now, I have to add a few conditionals to make it work like this:

```javascript
const myModel = computed(() => {
    const query = MyModel.query();

    if (toggleOne.isActive) {
        query.with('one', oneQuery => {
            if (searchQuery.value) {
                oneQuery.search(searchQuery.value);
            }
        });
    }

    if (toggleTwo.isActive) {
        query.with('two', twoQuery => {
            if (searchQuery.value) {
                twoQuery.search(searchQuery.value);
            }
        });
    }

    if (toggleThree.isActive) {
        query.with('three', threeQuery => {
            if (searchQuery.value) {
                threeQuery.search(searchQuery.value);
            }
        });
    }
    
    return query.find(id);
});
```

With a bit of refactoring, this could be rewritten to something like this:
```javascript
const myModel = computed(() => {
    const query = MyModel.query();

    if (toggleOne.isActive) {
        withOneQuery(query);
    }

    if (toggleTwo.isActive) {
        withTwoQuery(query);
    }

    if (toggleThree.isActive) {
        withThreeQuery(query);
    }

    return query.find(id);
});
```

I haven't included the `with[...]Query` methods in the previous example, as I think it's pretty obvious what each method will do.

So with a `when` helper (just like with [Laravel](https://laravel.com/docs/5.5/queries#conditional-clauses)), you will get something like this, which looks a lot cleaner to me:

```javascript
const myModel = computed(() => MyModel.query()
    .when(toggleOne.isActive, withOneQuery)
    .when(toggleTwo.isActive, withTwoQuery)
    .when(toggleThree.isActive, withThreeQuery)
    .find(id)
);
```

This would also allow for a default callback when the conditional results in something falsy. The conditional itself, is added as the second parameter in the callback.

```javascript
MyModel.query().when(
    isTrueOrFalse,
    (query, conditional) => console.log(query, conditional),
    (query, conditional) => console.log(query, conditional)
)
```

### Todo
- [x] Add UnitTests (?)
- [ ] Add documentation (?)